### PR TITLE
Fix sheet name length calculation

### DIFF
--- a/src/worksheet.rs
+++ b/src/worksheet.rs
@@ -221,7 +221,7 @@ impl Worksheet {
         }
 
         // Check that sheet sheetname is <= 31, an Excel limit.
-        if name.len() > 31 {
+        if name.chars().count() > 31 {
             return Err(XlsxError::SheetnameLengthExceeded(name.to_string()));
         }
 


### PR DESCRIPTION
Xlsx supports sheet names with 31 characters.
But &str.len() is returning utf8 bytes count instead of chars count.
I checked this fix with cyrillic sheet name.