### PR TITLE
Fix "duplication" of methods Workbook::save_to_path and Workbook::save

### DIFF
--- a/examples/doc_workbook_save_to_path.rs
+++ b/examples/doc_workbook_save_to_path.rs
@@ -12,7 +12,7 @@ fn main() -> Result<(), XlsxError> {
 
     _ = workbook.add_worksheet();
 
-    workbook.save_to_path(&path)?;
+    workbook.save(&path)?;
 
     Ok(())
 }

--- a/tests/bootstrap01.rs
+++ b/tests/bootstrap01.rs
@@ -37,7 +37,7 @@ fn create_new_xlsx_file_3(filename: &str) -> Result<(), XlsxError> {
     let mut workbook = Workbook::new();
     _ = workbook.add_worksheet();
 
-    workbook.save_to_path(&path)?;
+    workbook.save(&path)?;
 
     Ok(())
 }
@@ -50,7 +50,7 @@ fn create_new_xlsx_file_4(filename: &str) -> Result<(), XlsxError> {
     let mut workbook = Workbook::new();
     _ = workbook.add_worksheet();
 
-    workbook.save_to_path(&path)?;
+    workbook.save(&path)?;
 
     Ok(())
 }


### PR DESCRIPTION
Main point is to use generics instead of enum and second function.
We can't convert Path to &str safely, but we can convert &str to Path via impl AsRef<Path> for str