### PR TITLE
Minify `CellType`

### DIFF
--- a/src/shared_strings.rs
+++ b/src/shared_strings.rs
@@ -85,13 +85,13 @@ mod tests {
 
         let mut shared_strings = SharedStrings::new();
 
-        string_table.shared_string_index("neptune");
-        string_table.shared_string_index("neptune");
-        string_table.shared_string_index("neptune");
-        string_table.shared_string_index("neptune");
-        string_table.shared_string_index("mars");
-        string_table.shared_string_index("venus");
-        string_table.shared_string_index("mars");
+        string_table.shared_string_index("neptune".into());
+        string_table.shared_string_index("neptune".into());
+        string_table.shared_string_index("neptune".into());
+        string_table.shared_string_index("neptune".into());
+        string_table.shared_string_index("mars".into());
+        string_table.shared_string_index("venus".into());
+        string_table.shared_string_index("mars".into());
 
         shared_strings.assemble_xml_file(&string_table);
 
@@ -124,9 +124,9 @@ mod tests {
 
         let mut shared_strings = SharedStrings::new();
 
-        string_table.shared_string_index("abcdefg");
-        string_table.shared_string_index("   abcdefg");
-        string_table.shared_string_index("abcdefg   ");
+        string_table.shared_string_index("abcdefg".into());
+        string_table.shared_string_index("   abcdefg".into());
+        string_table.shared_string_index("abcdefg   ".into());
 
         shared_strings.assemble_xml_file(&string_table);
 

--- a/src/worksheet/tests.rs
+++ b/src/worksheet/tests.rs
@@ -366,13 +366,10 @@ mod worksheet_tests {
             ),
         ];
 
-        for test_data in formulas.iter() {
-            let mut formula = test_data.0.to_string();
-            let expected = test_data.1;
+        for &(formula, expected) in &formulas {
+            let prepared_formula = prepare_formula(formula, true);
 
-            formula = prepare_formula(&formula, true);
-
-            assert_eq!(formula, expected);
+            assert_eq!(prepared_formula.as_ref(), expected);
         }
     }
 


### PR DESCRIPTION
I changed some fields' types of the `CellType` enum from `String` to `Box<str>` or `Rc<str>`. Result:
||Before|After|
|-|---------|-------|
|Size (Bytes)|80|56|
|Alignment|8|6|

This improves cache locality and allows the compiler to better optimize its use.

I also refactored the `prepare_formula` function because I needed it to output a `Box<str>` instead of a `String`.

### Why `Rc<str>`?
To improve the performance of the `shared_string_index` function. This is a hot function that needs to clone strings some of the time. By using `Rc<str>` the clones become really cheap.

![image](https://user-images.githubusercontent.com/11708972/231065263-9ba74c4b-3be5-4b53-9afa-ad707c8f929e.png)

