### PR TITLE
Remove possible bug concerning "'" in sheet name

### DIFF
--- a/src/chart.rs
+++ b/src/chart.rs
@@ -5142,11 +5142,10 @@ impl ChartRange {
             last_col = first_col;
         }
 
-        let sheet_name: String = if sheet_name.starts_with('\'') && sheet_name.ends_with('\'') {
-            sheet_name[1..sheet_name.len() - 1].to_string()
-        } else {
-            sheet_name.to_string()
-        };
+        let sheet_name: String = sheet_name
+            .strip_prefix('\'').unwrap_or(sheet_name)
+            .strip_suffix('\'').unwrap_or(sheet_name)
+            .to_string();
 
         ChartRange {
             sheet_name,


### PR DESCRIPTION
The excel standard says not to use apostrophes before OR after the sheet name, but this would only trigger if you had them both in your sheet name.

Also strip_suffix/prefix are more idiomatic (and technically protect from panics in non-UTF strings, but that is not relevant here since ' is always one byte)

Belongs to issue #44 