### PR TITLE
Centralize name validation into worksheet::Name struct

### DIFF
--- a/src/chart.rs
+++ b/src/chart.rs
@@ -5142,11 +5142,10 @@ impl ChartRange {
             last_col = first_col;
         }
 
-        let sheet_name: String = if sheet_name.starts_with('\'') && sheet_name.ends_with('\'') {
-            sheet_name[1..sheet_name.len() - 1].to_string()
-        } else {
-            sheet_name.to_string()
-        };
+        let sheet_name: String = sheet_name
+            .strip_prefix('\'').unwrap_or(sheet_name)
+            .strip_suffix('\'').unwrap_or(sheet_name)
+            .to_string();
 
         ChartRange {
             sheet_name,

--- a/src/error.rs
+++ b/src/error.rs
@@ -38,6 +38,9 @@ pub enum XlsxError {
     /// Worksheet name cannot start or end with an apostrophe.
     SheetnameStartsOrEndsWithApostrophe(String),
 
+    /// Worksheet name cannot be "History"
+    SheetnameReserved,
+
     /// String exceeds Excel's limit of 32,767 characters.
     MaxStringLengthExceeded,
 
@@ -132,6 +135,13 @@ impl fmt::Display for XlsxError {
                 write!(
                     f,
                     "Worksheet name \"{name}\" cannot start or end with an apostrophe.",
+                )
+            }
+            
+            XlsxError::SheetnameReserved => {
+                write!(
+                    f,
+                    "\"History\" is a reserved worksheet name"
                 )
             }
 


### PR DESCRIPTION
Regarding issue #45 

I added a struct `Name` in the worksheet module.
it's a string wrapper that includes all the logic in `set_name`, and `set_name` was pointed to this struct.
I took care to not change and public interface so far, and as the field "name" was crate-public, I changed it to an `Option<Name>` so the validation could stay guaranteed.
So far this setup passes all the tests, and any tests concering set_name were kept, so this should work as before.