### PR TITLE
Add support for rust_decimal as a feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ polars = {version = "0.45", default-features = false, features = [], optional = 
 tempfile =  {version = "3.14.0", optional = true}
 wasm-bindgen = {version = "0.2.99", optional = true}
 rust_xlsxwriter_derive = {version = "0.2.0", optional = true}
-rusty-money = {version = "0.4.1", optional = true}
 rust_decimal = {version = "1.36.0", optional = true}
 
 [dev-dependencies]
@@ -52,9 +51,9 @@ constant_memory = ["dep:tempfile"]
 # easier to write.
 polars = ["dep:polars"]
 
-# `rusty_money`: Add support for writing rusty_money Money type with
-# `Worksheet.write()`
-rusty_money = ["dep:rusty-money", "dep:rust_decimal"]
+# `rust_decimal`: Add support for writing rust_decimal Decimal type with
+# `Worksheet.write()`, provided it can be represented by f64
+rust_decimal = ["dep:rust_decimal"]
 
 # `serde`: Adds supports for Serde serialization.
 serde = ["dep:serde", "dep:rust_xlsxwriter_derive"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,8 +51,8 @@ constant_memory = ["dep:tempfile"]
 # easier to write.
 polars = ["dep:polars"]
 
-# `rust_decimal`: Add support for writing rust_decimal Decimal type with
-# `Worksheet.write()`, provided it can be represented by f64
+# `rust_decimal`: Add support for writing `rust_decimal` `Decimal` type with
+# `Worksheet::write()`, provided it can be represented by f64.
 rust_decimal = ["dep:rust_decimal"]
 
 # `serde`: Adds supports for Serde serialization.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ polars = {version = "0.45", default-features = false, features = [], optional = 
 tempfile =  {version = "3.14.0", optional = true}
 wasm-bindgen = {version = "0.2.99", optional = true}
 rust_xlsxwriter_derive = {version = "0.2.0", optional = true}
+rusty-money = {version = "0.4.1", optional = true}
+rust_decimal = {version = "1.36.0", optional = true}
 
 [dev-dependencies]
 regex = "1.11.1"
@@ -49,6 +51,10 @@ constant_memory = ["dep:tempfile"]
 # `rust_xlsxwriter::XlsxError` to make code that handles both types of error
 # easier to write.
 polars = ["dep:polars"]
+
+# `rusty_money`: Add support for writing rusty_money Money type with
+# `Worksheet.write()`
+rusty_money = ["dep:rusty-money", "dep:rust_decimal"]
 
 # `serde`: Adds supports for Serde serialization.
 serde = ["dep:serde", "dep:rust_xlsxwriter_derive"]

--- a/src/worksheet.rs
+++ b/src/worksheet.rs
@@ -1262,10 +1262,8 @@ use std::fs::File;
 #[cfg(feature = "chrono")]
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 
-#[cfg(feature = "rusty_money")]
-use rusty_money::{FormattableCurrency, Money};
-#[cfg(feature = "rusty_money")]
-use rust_decimal::prelude::ToPrimitive;
+#[cfg(feature = "rust_decimal")]
+use rust_decimal::prelude::{ToPrimitive, Decimal};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -18112,16 +18110,16 @@ impl IntoExcelData for &NaiveTime {
     }
 }
 
-#[cfg(feature = "rusty_money")]
-impl<'b, T: FormattableCurrency> IntoExcelData for Money<'_, T> {
+#[cfg(feature = "rust_decimal")]
+impl IntoExcelData for Decimal {
     fn write(
         self,
         worksheet: &mut Worksheet,
         row: RowNum,
         col: ColNum,
     ) -> Result<&mut Worksheet, XlsxError> {
-        let Some(number) = self.amount().to_f64() else {
-            return Err(XlsxError::ParameterError(format!("Cannot represent {:?} in excel", self.amount())));
+        let Some(number) = self.to_f64() else {
+            return Err(XlsxError::ParameterError(format!("Cannot represent {:?} in a single cell", self)));
         };
         worksheet.store_number(row, col, number, None)
     }
@@ -18133,8 +18131,8 @@ impl<'b, T: FormattableCurrency> IntoExcelData for Money<'_, T> {
         col: ColNum,
         format: &Format,
     ) -> Result<&'a mut Worksheet, XlsxError> {
-        let Some(number) = self.amount().to_f64() else {
-            return Err(XlsxError::ParameterError(format!("Cannot represent {:?} in excel", self.amount())));
+        let Some(number) = self.to_f64() else {
+            return Err(XlsxError::ParameterError(format!("Cannot represent {:?} in a single cell", self)));
         };
         worksheet.store_number(row, col, number, Some(format))
     }

--- a/src/worksheet.rs
+++ b/src/worksheet.rs
@@ -1263,7 +1263,7 @@ use std::fs::File;
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 
 #[cfg(feature = "rust_decimal")]
-use rust_decimal::prelude::{ToPrimitive, Decimal};
+use rust_decimal::prelude::{Decimal, ToPrimitive};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -18119,12 +18119,15 @@ impl IntoExcelData for Decimal {
         col: ColNum,
     ) -> Result<&mut Worksheet, XlsxError> {
         let Some(number) = self.to_f64() else {
-            return Err(XlsxError::ParameterError(format!("Cannot represent {:?} in a single cell", self)));
+            return Err(XlsxError::ParameterError(format!(
+                "Cannot represent {:?} in a single cell",
+                self
+            )));
         };
         worksheet.store_number(row, col, number, None)
     }
 
-    fn write_with_format<'a> (
+    fn write_with_format<'a>(
         self,
         worksheet: &'a mut Worksheet,
         row: RowNum,
@@ -18132,7 +18135,10 @@ impl IntoExcelData for Decimal {
         format: &Format,
     ) -> Result<&'a mut Worksheet, XlsxError> {
         let Some(number) = self.to_f64() else {
-            return Err(XlsxError::ParameterError(format!("Cannot represent {:?} in a single cell", self)));
+            return Err(XlsxError::ParameterError(format!(
+                "Cannot represent {:?} in a single cell",
+                self
+            )));
         };
         worksheet.store_number(row, col, number, Some(format))
     }

--- a/src/worksheet.rs
+++ b/src/worksheet.rs
@@ -18120,7 +18120,7 @@ impl IntoExcelData for Decimal {
     ) -> Result<&mut Worksheet, XlsxError> {
         let Some(number) = self.to_f64() else {
             return Err(XlsxError::ParameterError(format!(
-                "Cannot represent {:?} in a single cell",
+                "Cannot represent Decimal {:?} as an Excel f64 value.",
                 self
             )));
         };
@@ -18136,7 +18136,7 @@ impl IntoExcelData for Decimal {
     ) -> Result<&'a mut Worksheet, XlsxError> {
         let Some(number) = self.to_f64() else {
             return Err(XlsxError::ParameterError(format!(
-                "Cannot represent {:?} in a single cell",
+                "Cannot represent Decimal {:?} as an Excel f64 value.",
                 self
             )));
         };


### PR DESCRIPTION
This adds a new rust_decimal feature to rust_xlsxwriter as a convenience method. It doesn't impact success of any tests.

1. https://github.com/jmcnamara/rust_xlsxwriter/issues/126
2. Added the ability to use the Decimal type from rust_decimal directly with Worksheet.write(), allowing it to be written directly to a worksheet like any excel value. 
```
let user_dollars = Decimal::new(210, 2); // $2.10
worksheet.write(0, 0, user_dollars)?;
```