### PR TITLE
#141 xmlwriter: fix when unicode after _x escape

### DIFF
--- a/src/xmlwriter.rs
+++ b/src/xmlwriter.rs
@@ -287,6 +287,10 @@ pub(crate) fn escape_xml_escapes(original: &str) -> Cow<str> {
             continue;
         }
 
+        if !original.is_char_boundary(index + 6) {
+            continue;
+        }
+
         // Check that the digits in _xABCD_ are a valid hex code.
         if original[index + 2..index + 6]
             .chars()

--- a/src/xmlwriter/tests.rs
+++ b/src/xmlwriter/tests.rs
@@ -177,4 +177,16 @@ mod xmlwriter_tests {
         let got = xmlwriter::cursor_to_str(&writer);
         assert_eq!(expected, got);
     }
+
+    #[test]
+    fn test_xml_si_escape_with_unicode() {
+        let expected = "<si><t>_x_1_½</t></si>";
+
+        let mut writer = Cursor::new(Vec::with_capacity(2048));
+
+        xml_si_element(&mut writer, "_x_1_½", false);
+
+        let got = xmlwriter::cursor_to_str(&writer);
+        assert_eq!(expected, got);
+    }
 }


### PR DESCRIPTION
Issue from user of my library here:

https://github.com/kindly/flatterer/issues/73

This is causing a panic when characters after `_x` are Unicode and the indexing into them is splitting a char.  Fix to make sure if the split is not on the char boundry then ignore as it would not be a hex escape sequence in that case.

