### PR TITLE
make `Worksheet: Sync`

### DIFF
--- a/src/conditional_format.rs
+++ b/src/conditional_format.rs
@@ -965,7 +965,7 @@ pub trait ConditionalFormat {
     fn has_x14_only(&self) -> bool;
 
     /// Clone a reference into a concrete Box type.
-    fn box_clone(&self) -> Box<dyn ConditionalFormat + Send>;
+    fn box_clone(&self) -> Box<dyn ConditionalFormat + Sync + Send>;
 }
 
 macro_rules! generate_conditional_format_impls {
@@ -1006,7 +1006,7 @@ macro_rules! generate_conditional_format_impls {
             }
 
 
-            fn box_clone(&self) -> Box<dyn ConditionalFormat + Send> {
+            fn box_clone(&self) -> Box<dyn ConditionalFormat + Sync + Send> {
                 Box::new(self.clone())
             }
         }

--- a/src/worksheet.rs
+++ b/src/worksheet.rs
@@ -1608,7 +1608,7 @@ pub struct Worksheet {
     filter_automatic_off: bool,
     has_drawing_object_linkage: bool,
     cells_with_autofilter: HashMap<(RowNum, ColNum), (FilterType, CellRange)>,
-    conditional_formats: BTreeMap<String, Vec<Box<dyn ConditionalFormat + Send>>>,
+    conditional_formats: BTreeMap<String, Vec<Box<dyn ConditionalFormat + Sync + Send>>>,
     conditional_format_order: Vec<String>,
     data_validations: BTreeMap<String, DataValidation>,
     has_conditional_formats: bool,
@@ -9014,7 +9014,7 @@ impl Worksheet {
         conditional_format: &T,
     ) -> Result<&mut Worksheet, XlsxError>
     where
-        T: ConditionalFormat + Send,
+        T: ConditionalFormat + Send + Sync,
     {
         // Check rows and cols are in the allowed range.
         if !self.check_dimensions_only(first_row, first_col)

--- a/src/worksheet/tests.rs
+++ b/src/worksheet/tests.rs
@@ -714,4 +714,9 @@ mod worksheet_tests {
         let result = worksheet.ignore_error(2, 1, IgnoreError::NumberStoredAsText);
         assert!(matches!(result, Err(XlsxError::ParameterError(_))));
     }
+
+    const _: () = {
+        const fn assert_worksheet_sync<S: Sync>() {}
+        assert_worksheet_sync::<Worksheet>();
+    };
 }

--- a/tests/integration/common/mod.rs
+++ b/tests/integration/common/mod.rs
@@ -35,12 +35,6 @@ use pretty_assertions::assert_eq;
 use regex::Regex;
 use rust_xlsxwriter::XlsxError;
 
-const _: () = {
-    const fn assert_worksheet_sync<S: Sync>() {}
-
-    assert_worksheet_sync::<rust_xlsxwriter::Worksheet>();
-};
-
 // Simple test runner struct and methods to create a new xlsx output file and
 // compare it with an input xlsx file created by Excel.
 #[allow(dead_code)]

--- a/tests/integration/common/mod.rs
+++ b/tests/integration/common/mod.rs
@@ -35,6 +35,12 @@ use pretty_assertions::assert_eq;
 use regex::Regex;
 use rust_xlsxwriter::XlsxError;
 
+const _: () = {
+    const fn assert_worksheet_sync<S: Sync>() {}
+
+    assert_worksheet_sync::<rust_xlsxwriter::Worksheet>();
+};
+
 // Simple test runner struct and methods to create a new xlsx output file and
 // compare it with an input xlsx file created by Excel.
 #[allow(dead_code)]


### PR DESCRIPTION
Adding `Sync` bounds to type within Worksheet for issue #144 