### PR TITLE
Update zip dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.73.0" # For zip.rs compatibility.
 
 [dependencies]
 # Default/non-optional dependencies.
-zip = { version = "2.5", default-features = false, features = ["deflate"] }
+zip = { version = "3.0", default-features = false, features = ["deflate"] }
 
 # Optional dependencies.
 ryu = {version = "1.0", optional = true}
@@ -36,7 +36,7 @@ default = []
 
 # `zlib`: Adds a dependency on zlib and a C compiler. This includes the same
 # features as `default` but is 1.5x faster for large files.
-zlib = ["zip/deflate-zlib"]
+zlib = ["zip/deflate"]
 
 # `chrono`: Adds support for Chrono dates/times in addition to the native
 # ExcelDateTime types.


### PR DESCRIPTION
Hi. Zip yanked versions used, which breaks build for users of `rust_xlsxwriter`.  Related issue https://github.com/jmcnamara/rust_xlsxwriter/issues/149